### PR TITLE
Add animation video project type

### DIFF
--- a/client/src/components/project-type-selector.tsx
+++ b/client/src/components/project-type-selector.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Building2, ShoppingBag, Shirt, Camera, Youtube } from "lucide-react";
+import { Building2, ShoppingBag, Shirt, Camera, Youtube, Clapperboard } from "lucide-react";
 import type { ProjectType } from "@shared/schema";
 
 const projectTypeConfig = {
@@ -37,6 +37,13 @@ const projectTypeConfig = {
     description: "Content creation, vlogs, tutorials, dan digital media",
     color: "text-red-600 dark:text-red-400",
     bgColor: "bg-red-600/10"
+  },
+  animation_video: {
+    icon: Clapperboard,
+    title: "Animation Video",
+    description: "Explainer, motion graphics, dan animated storytelling projects",
+    color: "text-amber-600 dark:text-amber-400",
+    bgColor: "bg-amber-600/10"
   }
 };
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -5,17 +5,18 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { 
-  Plus, 
-  Search, 
-  FileText, 
-  Calendar, 
-  DollarSign, 
+  Plus,
+  Search,
+  FileText,
+  Calendar,
+  DollarSign,
   TrendingUp,
   Building2,
   ShoppingBag,
   Shirt,
   Camera,
   Youtube,
+  Clapperboard,
   ArrowRight
 } from "lucide-react";
 import type { Project, ProjectType } from "@shared/schema";
@@ -27,7 +28,8 @@ const projectTypeIcons = {
   ads_commercial: ShoppingBag,
   fashion: Shirt,
   event_documentation: Camera,
-  youtube: Youtube
+  youtube: Youtube,
+  animation_video: Clapperboard
 };
 
 const projectTypeLabels = {
@@ -35,7 +37,8 @@ const projectTypeLabels = {
   ads_commercial: "Ads/Commercial",
   fashion: "Fashion",
   event_documentation: "Event Documentation",
-  youtube: "YouTube"
+  youtube: "YouTube",
+  animation_video: "Animation Video"
 };
 
 export default function Dashboard() {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { FileVideo, Building2, ShoppingBag, Shirt, Camera, Youtube, ArrowRight, BarChart3, FileText, Zap } from "lucide-react";
+import { FileVideo, Building2, ShoppingBag, Shirt, Camera, Youtube, Clapperboard, ArrowRight, BarChart3, FileText, Zap } from "lucide-react";
 import type { ProjectType } from "@shared/schema";
 
 const projectTypeConfig = {
@@ -35,6 +35,12 @@ const projectTypeConfig = {
     title: "YouTube Video",
     description: "Content creation & digital media",
     color: "text-red-600 dark:text-red-400"
+  },
+  animation_video: {
+    icon: Clapperboard,
+    title: "Animation Video",
+    description: "Explainer & motion graphic storytelling",
+    color: "text-amber-600 dark:text-amber-400"
   }
 };
 
@@ -93,7 +99,7 @@ export default function Home() {
                 </div>
                 <CardTitle>Choose Project Type</CardTitle>
                 <CardDescription>
-                  Select from 5 video categories with tailored complexity questionnaires
+                  Select from {Object.keys(projectTypeConfig).length} video categories with tailored complexity questionnaires
                 </CardDescription>
               </CardHeader>
             </Card>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -9,7 +9,8 @@ export const projectTypes = [
   "ads_commercial",
   "fashion",
   "event_documentation",
-  "youtube"
+  "youtube",
+  "animation_video"
 ] as const;
 
 export type ProjectType = typeof projectTypes[number];
@@ -141,21 +142,21 @@ export const complexityQuestions: ComplexityQuestion[] = [
     question: "Skala perusahaan (UMKM–Enterprise)?",
     description: "Ukuran dan budget capacity klien",
     weight: 1.3,
-    applicableTypes: ["company_profile", "ads_commercial"],
+    applicableTypes: ["company_profile", "ads_commercial", "animation_video"],
   },
   {
     id: "hospitality_needs",
     question: "Kira² client perlu Hospitality, tailored deck, offline meeting intensif?",
     description: "Level profesionalisme dan presentasi yang dibutuhkan",
     weight: 1.1,
-    applicableTypes: ["company_profile", "ads_commercial", "fashion"],
+    applicableTypes: ["company_profile", "ads_commercial", "fashion", "animation_video"],
   },
   {
     id: "client_type",
     question: "Clientnya product/service?",
     description: "Tipe bisnis klien (product-based vs service-based)",
     weight: 0.9,
-    applicableTypes: ["company_profile", "ads_commercial"],
+    applicableTypes: ["company_profile", "ads_commercial", "animation_video"],
   },
   {
     id: "concept_ownership",


### PR DESCRIPTION
## Summary
- add the animation video option to the shared schema and complexity questionnaire filters
- expose the animation video type across the project selector, home page marketing cards, and dashboard labels
- keep the onboarding copy in sync by reflecting the dynamic count of supported project categories

## Testing
- npm run check *(fails: existing TypeScript errors in pdf generation, quotation generator, and server storage)*

------
https://chatgpt.com/codex/tasks/task_e_6908f5bbf1d48331831157b45e73cfea